### PR TITLE
Update Firmware Repository.md

### DIFF
--- a/docs/Firmware Repository.md
+++ b/docs/Firmware Repository.md
@@ -193,7 +193,7 @@ A basic ADSL only BCM6362 based gateway. Very useful as SIP ATA.
 | 2      | 17.2.0188-820-RA | #2            | *No RBI available, this version has been found on some devices. If you have it on your device please share a dump! Ask for help if you don't know how to get the dump.* |
 | 2      | 17.2.0288-820-RA | #2            | [HTTP](http://fwstore.bdms.telstra.net/Technicolor_vbnt-v_CRF761-17.2.0288-820-RA/vbnt-v_CRF761-17.2.0288-820-RA.rbi) - [Torrent](https://github.com/kevdagoat/hack-technicolor/blob/master/torrents/vbnt-v/vbnt-v_CRF761-17.2.0288-820-RA.rbi.torrent?raw=true) |
 | 2      | 17.2.0320-820-RA | #2            | [HTTP](http://fwstore.bdms.telstra.net/Technicolor_vbnt-v_CRF795-17.2.0320-820-RA/vbnt-v_CRF795-17.2.0320-820-RA.rbi) - [Torrent](https://github.com/kevdagoat/hack-technicolor/blob/master/torrents/vbnt-v/vbnt-v_CRF795-17.2.0320-820-RA.rbi.torrent?raw=true) |
-| ???    | 17.2.0406-820-RC | -             | [HTTP](http://fwstore.bdms.telstra.net/Technicolor_vbnt-v_CRF909-17.2.0406-820-RC/vbnt-v_CRF909-17.2.0406-820-RC.rbi) - [Torrent](https://github.com/kevdagoat/hack-technicolor/blob/master/torrents/vbnt-v/vbnt-v_CRF909-17.2.0406-820-RC.rbi.torrent?raw=true) |
+| 2      | 17.2.0406-820-RC | #2            | [HTTP](http://fwstore.bdms.telstra.net/Technicolor_vbnt-v_CRF909-17.2.0406-820-RC/vbnt-v_CRF909-17.2.0406-820-RC.rbi) - [Torrent](https://github.com/kevdagoat/hack-technicolor/blob/master/torrents/vbnt-v/vbnt-v_CRF909-17.2.0406-820-RC.rbi.torrent?raw=true) |
 
 ## DJA0231 / VCNT-A
 


### PR DESCRIPTION
Ln 196, Firmware v_CRF909-17.2.0406-820-RC.rbi Type 2 from ??? (Unknown), Root Strategy #2 from ??? (Unknown). On 29/09/19 I had an unrooted DJA0230TLS which had fw v_CRF909-17.2.0406-820-RC.rbi , I ran script "tch-exploit-win --sts=D:\stsfile.sts" where the tch-exploit-win was version 1.05 and the "stsfile.sts" was created with RAW data inserted from "generic_wps_callback.STS". after running this I pushed the PAIR button, and the DJA0230TLS rebooted. I then had access via SSH on 192.168.0.1 port 22 to root.